### PR TITLE
v0.1.2: Audio file upload and playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.1.2] - 2026-02-07
+
+### Added
+- `POST /calls/:id/play/file` endpoint for uploading raw WAV/PCM audio and playing it on a channel
+- Sequential media playback: `POST /calls/:id/play` now accepts an array of media URIs
+- `playMediaSequence()` method in AriConnection for playing multiple media items in order
+- `uploadAndPlayFile()` method that uploads audio via ARI HTTP and plays it
+- `audio.asteriskSoundsDir` config option for configurable Asterisk sounds path
+- `ASTERISK_SOUNDS_DIR` environment variable
+
+### Changed
+- `PlayRequestSchema` now accepts both a single string and an array of strings for the `media` field
+
 ## [0.1.1] - 2026-02-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asterisk-api",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "description": "REST API bridge between OpenClaw and Asterisk/FreePBX via ARI",
   "main": "dist/index.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,10 @@ const ConfigSchema = z.object({
     host: z.string().default("0.0.0.0"),
     apiKey: z.string().optional(),
   }),
+  audio: z.object({
+    /** Base URL for uploading/managing sounds on Asterisk via ARI HTTP */
+    asteriskSoundsDir: z.string().default("/var/lib/asterisk/sounds/custom"),
+  }),
   openclaw: z.object({
     webhookUrl: z.string().url().optional(),
   }),
@@ -32,6 +36,9 @@ export function loadConfig(): Config {
       port: process.env.API_PORT,
       host: process.env.API_HOST,
       apiKey: process.env.API_KEY || undefined,
+    },
+    audio: {
+      asteriskSoundsDir: process.env.ASTERISK_SOUNDS_DIR,
     },
     openclaw: {
       webhookUrl: process.env.OPENCLAW_WEBHOOK_URL || undefined,


### PR DESCRIPTION
## Summary
- Add `POST /calls/:id/play/file` endpoint that accepts raw WAV audio body and plays it on a channel
- Add sequential media playback support — `POST /calls/:id/play` now accepts an array of media URIs
- Add `uploadAndPlayFile()` and `playMediaSequence()` methods to AriConnection
- Add `ASTERISK_SOUNDS_DIR` config option

## Test plan
- [ ] Verify `POST /calls/:id/play { media: ["sound:hello-world", "sound:goodbye"] }` plays sequentially
- [ ] Verify `POST /calls/:id/play/file` with `Content-Type: audio/wav` and raw WAV body returns 200
- [ ] Verify 400 returned when body is empty or not a valid buffer
- [ ] Verify new config option parsed correctly with default value

🤖 Generated with [Claude Code](https://claude.com/claude-code)