### PR TITLE
v0.1.3: Bridge management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.1.3] - 2026-02-07
+
+### Added
+- Bridge CRUD routes: `POST /bridges`, `GET /bridges`, `GET /bridges/:id`, `DELETE /bridges/:id`
+- Bridge channel management: `POST /bridges/:id/addChannel`, `POST /bridges/:id/removeChannel`
+- `POST /calls/:id/transfer` endpoint — creates a bridge, dials a new endpoint, and connects both channels
+- `BridgeRecord` type and `TransferRequest` type in types.ts
+- Bridge tracking in CallManager: `createBridge()`, `getBridge()`, `listBridges()`, `deleteBridge()`, `addChannelToBridge()`, `removeChannelFromBridge()`
+- `clearBridge()` method on CallManager to disassociate a call from a bridge
+- Bridge events emitted on the WebSocket stream (`bridge.created`, `bridge.destroyed`)
+
+### Changed
+- CallManager `setBridge()` now also sets call state to "bridged"
+
 ## [0.1.2] - 2026-02-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asterisk-api",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "description": "REST API bridge between OpenClaw and Asterisk/FreePBX via ARI",
   "main": "dist/index.js",

--- a/src/call-manager.ts
+++ b/src/call-manager.ts
@@ -1,11 +1,14 @@
 import { EventEmitter } from "node:events";
-import type { CallRecord, CallState, CallEvent } from "./types.js";
+import type { CallRecord, CallState, CallEvent, BridgeRecord } from "./types.js";
 
 /**
- * Manages active call state and emits events for the WebSocket stream.
+ * Manages active call and bridge state and emits events for the WebSocket stream.
  */
 export class CallManager extends EventEmitter {
   private calls = new Map<string, CallRecord>();
+  private bridges = new Map<string, BridgeRecord>();
+
+  // ── Call management ───────────────────────────────────────────────
 
   create(record: CallRecord): void {
     this.calls.set(record.id, record);
@@ -47,7 +50,20 @@ export class CallManager extends EventEmitter {
 
   setBridge(callId: string, bridgeId: string): void {
     const call = this.calls.get(callId);
-    if (call) call.bridgeId = bridgeId;
+    if (call) {
+      call.bridgeId = bridgeId;
+      call.state = "bridged";
+    }
+  }
+
+  clearBridge(callId: string): void {
+    const call = this.calls.get(callId);
+    if (call) {
+      call.bridgeId = undefined;
+      if (call.state === "bridged") {
+        call.state = "answered";
+      }
+    }
   }
 
   addRecording(callId: string, recordingName: string): void {
@@ -68,6 +84,52 @@ export class CallManager extends EventEmitter {
     // Clean up after 5 minutes
     setTimeout(() => this.calls.delete(callId), 5 * 60 * 1000);
   }
+
+  // ── Bridge management ─────────────────────────────────────────────
+
+  createBridge(record: BridgeRecord): void {
+    this.bridges.set(record.id, record);
+    this.emit("event", {
+      type: "bridge.created",
+      callId: "",
+      timestamp: new Date(),
+      data: { bridgeId: record.id, name: record.name, type: record.type },
+    } satisfies CallEvent);
+  }
+
+  getBridge(bridgeId: string): BridgeRecord | undefined {
+    return this.bridges.get(bridgeId);
+  }
+
+  listBridges(): BridgeRecord[] {
+    return Array.from(this.bridges.values());
+  }
+
+  addChannelToBridge(bridgeId: string, channelId: string): void {
+    const bridge = this.bridges.get(bridgeId);
+    if (bridge && !bridge.channelIds.includes(channelId)) {
+      bridge.channelIds.push(channelId);
+    }
+  }
+
+  removeChannelFromBridge(bridgeId: string, channelId: string): void {
+    const bridge = this.bridges.get(bridgeId);
+    if (bridge) {
+      bridge.channelIds = bridge.channelIds.filter((id) => id !== channelId);
+    }
+  }
+
+  deleteBridge(bridgeId: string): void {
+    this.bridges.delete(bridgeId);
+    this.emit("event", {
+      type: "bridge.destroyed",
+      callId: "",
+      timestamp: new Date(),
+      data: { bridgeId },
+    } satisfies CallEvent);
+  }
+
+  // ── Events ────────────────────────────────────────────────────────
 
   private emitCallEvent(callId: string, type: string, data: Record<string, unknown>): void {
     const event: CallEvent = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,3 +47,17 @@ export interface RecordRequest {
   maxDurationSeconds?: number;
   beep?: boolean;
 }
+
+export interface BridgeRecord {
+  id: string;
+  name?: string;
+  type: string;
+  channelIds: string[];
+  createdAt: Date;
+}
+
+export interface TransferRequest {
+  endpoint: string;
+  callerId?: string;
+  timeout?: number;
+}


### PR DESCRIPTION
## Summary
- Add bridge CRUD routes: `POST /bridges`, `GET /bridges`, `GET /bridges/:id`, `DELETE /bridges/:id`
- Add bridge channel management: `POST /bridges/:id/addChannel`, `POST /bridges/:id/removeChannel`
- Add `POST /calls/:id/transfer` endpoint that creates a bridge, dials a new endpoint, and connects both channels
- Add bridge tracking in CallManager with `BridgeRecord` type

## Test plan
- [ ] Verify `POST /bridges` creates a mixing bridge and returns bridge record
- [ ] Verify `GET /bridges` lists bridges from both ARI and local tracking
- [ ] Verify `POST /bridges/:id/addChannel { callId }` adds channel and sets call state to "bridged"
- [ ] Verify `POST /calls/:id/transfer { endpoint }` creates bridge and connects both legs
- [ ] Verify `DELETE /bridges/:id` destroys bridge and clears bridge association from calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)