### PR TITLE
v0.1.4: Recording management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.1.4] - 2026-02-07
+
+### Added
+- `GET /recordings` to list all stored recordings from Asterisk
+- `GET /recordings/:name` to get recording metadata
+- `POST /recordings/:name/copy` to copy a stored recording `{ destinationName }`
+- `DELETE /recordings/:name?stored=true` to delete stored recordings (vs. stopping live ones)
+- Recording management methods in AriConnection: `listStoredRecordings()`, `getStoredRecording()`, `deleteStoredRecording()`, `copyStoredRecording()`
+- `copyStored()` method added to ari-client type declarations
+
+### Changed
+- Renamed `getRecording()` to `getRecordingFile()` for clarity (file download vs. metadata)
+- `DELETE /recordings/:name` now supports `?stored=true` query param to distinguish between stopping a live recording and deleting a stored one
+
 ## [0.1.3] - 2026-02-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asterisk-api",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "description": "REST API bridge between OpenClaw and Asterisk/FreePBX via ARI",
   "main": "dist/index.js",

--- a/src/ari-connection.ts
+++ b/src/ari-connection.ts
@@ -419,15 +419,70 @@ export class AriConnection {
   }
 
   /**
-   * Get a stored recording file.
+   * Get a stored recording file (binary data).
    */
-  async getRecording(recordingName: string): Promise<Buffer> {
+  async getRecordingFile(recordingName: string): Promise<Buffer> {
     this.requireConnection();
     try {
       return await this.ari.recordings.getStoredFile({ recordingName });
     } catch (err: any) {
       const parsed = parseAriError(err);
+      throw new AriError(`Recording file '${recordingName}' not found: ${parsed.message}`, 404);
+    }
+  }
+
+  /**
+   * List all stored recordings.
+   */
+  async listStoredRecordings(): Promise<any[]> {
+    this.requireConnection();
+    try {
+      return await this.ari.recordings.listStored();
+    } catch (err: any) {
+      const parsed = parseAriError(err);
+      throw new AriError(`List recordings failed: ${parsed.message}`, parsed.statusCode);
+    }
+  }
+
+  /**
+   * Get stored recording metadata (not the file, just metadata).
+   */
+  async getStoredRecording(recordingName: string): Promise<any> {
+    this.requireConnection();
+    try {
+      return await this.ari.recordings.getStored({ recordingName });
+    } catch (err: any) {
+      const parsed = parseAriError(err);
       throw new AriError(`Recording '${recordingName}' not found: ${parsed.message}`, 404);
+    }
+  }
+
+  /**
+   * Delete a stored recording.
+   */
+  async deleteStoredRecording(recordingName: string): Promise<void> {
+    this.requireConnection();
+    try {
+      await this.ari.recordings.deleteStored({ recordingName });
+    } catch (err: any) {
+      const parsed = parseAriError(err);
+      throw new AriError(`Delete recording '${recordingName}' failed: ${parsed.message}`, parsed.statusCode);
+    }
+  }
+
+  /**
+   * Copy a stored recording to a new name.
+   */
+  async copyStoredRecording(recordingName: string, destinationName: string): Promise<any> {
+    this.requireConnection();
+    try {
+      return await this.ari.recordings.copyStored({
+        recordingName,
+        destinationRecordingName: destinationName,
+      });
+    } catch (err: any) {
+      const parsed = parseAriError(err);
+      throw new AriError(`Copy recording '${recordingName}' failed: ${parsed.message}`, parsed.statusCode);
     }
   }
 

--- a/src/types/ari-client.d.ts
+++ b/src/types/ari-client.d.ts
@@ -77,6 +77,7 @@ declare module "ari-client" {
     getStoredFile(params: { recordingName: string }): Promise<Buffer>;
     listStored(): Promise<any[]>;
     deleteStored(params: { recordingName: string }): Promise<void>;
+    copyStored(params: { recordingName: string; destinationRecordingName: string }): Promise<any>;
   }
 
   interface AriPlaybacksApi {


### PR DESCRIPTION
## Summary
- Add `GET /recordings` to list all stored recordings from Asterisk
- Add `GET /recordings/:name` to get recording metadata
- Add `POST /recordings/:name/copy` to copy a stored recording
- Add `DELETE /recordings/:name?stored=true` to delete stored recordings
- Add recording management methods to AriConnection and `copyStored` to ari-client types

## Test plan
- [ ] Verify `GET /recordings` returns list of stored recordings
- [ ] Verify `GET /recordings/:name` returns metadata for a specific recording
- [ ] Verify `GET /recordings/:name/file` returns audio data with `Content-Type: audio/wav`
- [ ] Verify `POST /recordings/:name/copy { destinationName }` creates a copy
- [ ] Verify `DELETE /recordings/:name?stored=true` deletes a stored recording
- [ ] Verify `DELETE /recordings/:name` (without query param) still stops a live recording

🤖 Generated with [Claude Code](https://claude.com/claude-code)