### PR TITLE
feat(allowlist): Add allowlist.json config (v0.1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.1.5] - 2026-02-07
+
+### Added
+- `allowlist.json` configuration file for inbound/outbound phone number filtering
+- `allowlist.schema.json` JSON Schema for allowlist validation
+- `src/allowlist.ts` module with:
+  - `loadAllowlist()` — load allowlist from JSON file
+  - `watchAllowlist()` — auto-reload on file changes
+  - `isOutboundAllowed(endpoint)` — check if outbound call is permitted
+  - `isInboundAllowed(callerId)` — check if inbound caller is permitted
+  - `normalizeNumber()` — strip non-digit characters
+  - `extractNumberFromEndpoint()` — extract phone number from SIP endpoint string
+- Allowlist loaded on server startup with hot-reload support
+
+### Notes
+- Empty allowlist arrays = allow all (open mode)
+- Numbers stored without '+' prefix (e.g., "659654255" not "+659654255")
+
 ## [0.1.4] - 2026-02-07
 
 ### Added

--- a/allowlist.json
+++ b/allowlist.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "./allowlist.schema.json",
+  "description": "Allowlist for inbound and outbound calls. Numbers without '+' prefix.",
+  "inbound": [
+    "659654255"
+  ],
+  "outbound": [
+    "659654255"
+  ]
+}

--- a/allowlist.schema.json
+++ b/allowlist.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Asterisk API Allowlist",
+  "description": "Configuration for allowed inbound and outbound phone numbers",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema reference"
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable description of this allowlist"
+    },
+    "inbound": {
+      "type": "array",
+      "description": "Phone numbers allowed to call in (caller ID must match)",
+      "items": {
+        "type": "string",
+        "pattern": "^[0-9]+$",
+        "description": "Phone number without '+' prefix"
+      },
+      "default": []
+    },
+    "outbound": {
+      "type": "array",
+      "description": "Phone numbers allowed to be called (destination must match)",
+      "items": {
+        "type": "string",
+        "pattern": "^[0-9]+$",
+        "description": "Phone number without '+' prefix"
+      },
+      "default": []
+    }
+  },
+  "required": ["inbound", "outbound"],
+  "additionalProperties": false
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asterisk-api",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "description": "REST API bridge between OpenClaw and Asterisk/FreePBX via ARI",
   "main": "dist/index.js",

--- a/src/allowlist.ts
+++ b/src/allowlist.ts
@@ -1,0 +1,155 @@
+/**
+ * Allowlist Management
+ * Loads and checks phone numbers against inbound/outbound allowlists
+ *
+ * @module allowlist
+ */
+
+import { readFileSync, existsSync, watchFile } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export interface Allowlist {
+  inbound: string[];
+  outbound: string[];
+}
+
+let cachedAllowlist: Allowlist | null = null;
+let allowlistPath: string | null = null;
+
+/**
+ * Normalize a phone number by removing all non-digit characters
+ */
+export function normalizeNumber(input: string | undefined | null): string {
+  if (!input) return "";
+  return input.replace(/\D/g, "");
+}
+
+/**
+ * Extract the phone number from an endpoint string
+ * e.g., "PJSIP/trunk-provider/6596542555" → "6596542555"
+ * e.g., "SIP/6596542555@provider" → "6596542555"
+ * e.g., "PJSIP/6596542555" → "6596542555"
+ */
+export function extractNumberFromEndpoint(endpoint: string): string {
+  // Try to find a sequence of digits that looks like a phone number (7+ digits)
+  const matches = endpoint.match(/\d{7,}/g);
+  if (matches && matches.length > 0) {
+    // Return the longest match (most likely the full phone number)
+    return matches.reduce((a, b) => (a.length >= b.length ? a : b));
+  }
+  return "";
+}
+
+/**
+ * Load the allowlist from allowlist.json
+ */
+export function loadAllowlist(customPath?: string): Allowlist {
+  const filePath = customPath || resolve(__dirname, "../allowlist.json");
+  allowlistPath = filePath;
+
+  if (!existsSync(filePath)) {
+    console.warn(`[Allowlist] File not found: ${filePath} — using empty allowlist`);
+    cachedAllowlist = { inbound: [], outbound: [] };
+    return cachedAllowlist;
+  }
+
+  try {
+    const content = readFileSync(filePath, "utf-8");
+    const data = JSON.parse(content);
+
+    cachedAllowlist = {
+      inbound: Array.isArray(data.inbound) ? data.inbound.map(normalizeNumber) : [],
+      outbound: Array.isArray(data.outbound) ? data.outbound.map(normalizeNumber) : [],
+    };
+
+    console.log(
+      `[Allowlist] Loaded — inbound: ${cachedAllowlist.inbound.length}, outbound: ${cachedAllowlist.outbound.length}`
+    );
+
+    return cachedAllowlist;
+  } catch (err) {
+    console.error(`[Allowlist] Failed to load ${filePath}:`, err);
+    cachedAllowlist = { inbound: [], outbound: [] };
+    return cachedAllowlist;
+  }
+}
+
+/**
+ * Watch the allowlist file for changes and reload automatically
+ */
+export function watchAllowlist(): void {
+  if (!allowlistPath || !existsSync(allowlistPath)) return;
+
+  watchFile(allowlistPath, { interval: 5000 }, () => {
+    console.log("[Allowlist] File changed, reloading...");
+    loadAllowlist(allowlistPath!);
+  });
+}
+
+/**
+ * Get the current allowlist (loads if not cached)
+ */
+export function getAllowlist(): Allowlist {
+  if (!cachedAllowlist) {
+    return loadAllowlist();
+  }
+  return cachedAllowlist;
+}
+
+/**
+ * Check if a phone number is allowed for outbound calls
+ */
+export function isOutboundAllowed(endpoint: string): boolean {
+  const allowlist = getAllowlist();
+
+  // If allowlist is empty, allow all (open mode)
+  if (allowlist.outbound.length === 0) {
+    return true;
+  }
+
+  const number = extractNumberFromEndpoint(endpoint);
+  if (!number) {
+    console.warn(`[Allowlist] Could not extract number from endpoint: ${endpoint}`);
+    return false;
+  }
+
+  const allowed = allowlist.outbound.includes(number);
+  if (!allowed) {
+    console.warn(`[Allowlist] Outbound blocked: ${number} (from ${endpoint})`);
+  }
+  return allowed;
+}
+
+/**
+ * Check if a caller ID is allowed for inbound calls
+ */
+export function isInboundAllowed(callerId: string | undefined | null): boolean {
+  const allowlist = getAllowlist();
+
+  // If allowlist is empty, allow all (open mode)
+  if (allowlist.inbound.length === 0) {
+    return true;
+  }
+
+  const number = normalizeNumber(callerId);
+  if (!number) {
+    console.warn(`[Allowlist] Inbound call with no caller ID — blocked`);
+    return false;
+  }
+
+  const allowed = allowlist.inbound.includes(number);
+  if (!allowed) {
+    console.warn(`[Allowlist] Inbound blocked: ${number}`);
+  }
+  return allowed;
+}
+
+/**
+ * Reload the allowlist from disk
+ */
+export function reloadAllowlist(): Allowlist {
+  return loadAllowlist(allowlistPath || undefined);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,14 @@ import { CallManager } from "./call-manager.js";
 import { AriConnection } from "./ari-connection.js";
 import { createApi } from "./api.js";
 import { attachWebSocketServer } from "./ws-server.js";
+import { loadAllowlist, watchAllowlist } from "./allowlist.js";
 
 async function main() {
   const config = loadConfig();
+
+  // Load allowlist for inbound/outbound call filtering
+  loadAllowlist();
+  watchAllowlist();
   const callManager = new CallManager();
   const ariConn = new AriConnection(config, callManager);
 


### PR DESCRIPTION
## Changes

- Add `allowlist.json` with inbound/outbound phone number arrays
- Add `allowlist.schema.json` for validation
- Add `src/allowlist.ts` module with load/check functions
- Load allowlist on startup with hot-reload support

## Notes
- Empty arrays = allow all (open mode)
- Numbers stored without '+' prefix (e.g., `659654255`)

## Version
0.1.5