### PR TITLE
feat(allowlist): Enforce allowlist on calls (v0.1.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.1.6] - 2026-02-07
+
+### Added
+- `GET /allowlist` endpoint to view current inbound/outbound allowlist
+- `POST /allowlist/reload` endpoint to reload allowlist from file
+- Outbound allowlist enforcement on `POST /calls` — returns 403 if destination not in allowlist
+- Inbound allowlist enforcement on `StasisStart` — hangs up calls from non-allowed callers
+
+### Changed
+- `POST /calls` now returns detailed 403 error when blocked by allowlist, including extracted number and hint
+
+### Security
+- Shared trunk now protected by allowlist at API level
+- Both inbound and outbound calls filtered before processing
+
 ## [0.1.5] - 2026-02-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asterisk-api",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "description": "REST API bridge between OpenClaw and Asterisk/FreePBX via ARI",
   "main": "dist/index.js",


### PR DESCRIPTION
## Changes

- Add `GET /allowlist` endpoint to view current inbound/outbound lists
- Add `POST /allowlist/reload` to hot-reload from file
- Block outbound calls (`POST /calls`) if destination not in allowlist (returns 403)
- Block inbound calls (`StasisStart`) if caller not in allowlist (hangs up)
- Return detailed error with extracted number and hint

## Security
Shared trunk now protected at API level for both directions.

## Version
0.1.6