### PR TITLE
fix: clean up inbound call flow — remove test greeting, fix duplicate events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,6 @@ OPENCLAW_WEBHOOK_URL=http://host.docker.internal:18789/voice/webhook
 
 # Inbound call handling
 INBOUND_RING_DELAY_MS=3000   # Wait before answering (ms) - simulates ringing
-INBOUND_GREETING_SOUND=hello-world  # Sound file to play after answering
 
 # ASR (speech recognition) service WebSocket URL (optional — omit to disable ASR)
 ASR_URL=ws://192.168.2.198:8100/ws/transcribe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.3.3] - 2026-02-07
+
+### Fixed
+- **Removed test greeting from inbound calls** — every inbound call was playing `sound:hello-world` + `sound:beep` before reaching "ready" state; this was test scaffolding that delayed call readiness by ~1-2s. After answer, calls now go straight to "ready" and start audio capture immediately. Fixes #19.
+- **ChannelStateChange no longer duplicates "answered" on inbound calls** — the global handler now only transitions outbound calls; inbound calls manage their own state in the StasisStart handler. Fixes #20.
+
+### Removed
+- **`INBOUND_GREETING_SOUND` config** — no longer needed (no greeting played on inbound calls)
+
 ## [0.3.2] - 2026-02-07
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asterisk-api",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "description": "REST API bridge between OpenClaw and Asterisk/FreePBX via ARI",
   "main": "dist/index.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,8 +17,6 @@ const ConfigSchema = z.object({
   inbound: z.object({
     /** Delay in ms before answering inbound calls (simulates ringing) */
     ringDelayMs: z.coerce.number().int().min(0).default(3000),
-    /** Default greeting sound to play after answering */
-    greetingSound: z.string().default("hello-world"),
   }),
   asr: z.object({
     url: z.string().url().optional(),
@@ -52,7 +50,6 @@ export function loadConfig(): Config {
     audio: {},
     inbound: {
       ringDelayMs: process.env.INBOUND_RING_DELAY_MS,
-      greetingSound: process.env.INBOUND_GREETING_SOUND,
     },
     asr: {
       url: process.env.ASR_URL,


### PR DESCRIPTION
## Summary

- **Remove test greeting** — every inbound call played `sound:hello-world` + `sound:beep` before reaching "ready" state. This was test scaffolding that delayed call readiness by ~1-2s. After answer, calls now go straight to "ready" and start audio capture immediately. Fixes #19.
- **Fix duplicate "answered" events** — `ChannelStateChange` handler now only transitions outbound calls. Inbound calls manage their own state in the StasisStart handler, preventing duplicate `call.state_changed` events. Fixes #20.
- **Remove `INBOUND_GREETING_SOUND` config** — dead code, no greeting played anymore.

## New inbound flow

```
T+0s   Call arrives → "ringing" → webhook: call.inbound
T+3s   Ring delay → answer → "answered" → "ready" immediately
       → Audio capture + ASR start
```

## Test plan

- [ ] Call in — should answer after 3s ring delay, NO greeting or beep
- [ ] Audio capture starts immediately after answer
- [ ] Outbound calls still transition to "answered" via ChannelStateChange
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)