### PR TITLE
fix: wait for ASR flush response before closing WebSocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.4] - 2026-02-07
+
+### Fixed
+- **ASR flush waits for final transcription** — `close()` now sends flush and waits for the `is_final: true` response (up to 2s safety timeout) instead of a fixed 100ms delay, preventing the last words from being lost when a call ends. Fixes #22.
+
 ## [0.3.3] - 2026-02-07
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asterisk-api",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "description": "REST API bridge between OpenClaw and Asterisk/FreePBX via ARI",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- `close()` now sends flush and waits for the `is_final: true` response instead of a fixed 100ms delay
- 2s safety timeout prevents hanging if the ASR server never responds
- Final transcription is emitted as a `transcription` event so it's captured by listeners
- WebSocket `close` event also resolves the wait (graceful cleanup)

## Test plan
- [ ] Originate a call, speak, hang up — verify last words appear in transcription
- [ ] Test with ASR server down — verify 2s timeout fires and close completes
- [ ] Verify no WebSocket listener leaks after close

Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)