### PR TITLE
fix: ASR language locking, flush wait, and inbound ringing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
-## [0.3.4] - 2026-02-07
+## [0.3.5] - 2026-02-07
 
 ### Fixed
 - **ASR flush waits for final transcription** — `close()` now sends flush and waits for the `is_final: true` response (up to 2s safety timeout) instead of a fixed 100ms delay, preventing the last words from being lost when a call ends. Fixes #22.
+- **ASR language locking** — client sends `{"action": "config", "language": "English"}` on connect to prevent per-chunk auto-detection flipping between languages on silence/noise
+- **Inbound ringing indication** — added `channel.ring()` so callers hear a ringtone during the 3s pre-answer delay instead of silence
+
+### Added
+- `ASR_LANGUAGE` env var (default: `"English"`) — configures the language sent to the ASR service
 
 ## [0.3.3] - 2026-02-07
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asterisk-api",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "module",
   "description": "REST API bridge between OpenClaw and Asterisk/FreePBX via ARI",
   "main": "dist/index.js",

--- a/src/asr-client.ts
+++ b/src/asr-client.ts
@@ -17,6 +17,8 @@ export interface AsrTranscription {
 export interface AsrClientOptions {
   /** ASR WebSocket URL */
   url: string;
+  /** Language code for transcription (e.g. "en", "zh") or "auto" (default: "en") */
+  language?: string;
   /** Reconnect delay in ms (default: 2000) */
   reconnectDelay?: number;
   /** Max reconnect attempts (default: 10, 0 = infinite) */
@@ -126,6 +128,13 @@ export class AsrClient extends EventEmitter {
           reject(err);
         });
       });
+
+      // Configure language (default: "en" to avoid auto-detect flipping)
+      const language = this.options.language ?? "en";
+      if (language !== "auto") {
+        this.ws.send(JSON.stringify({ action: "config", language }));
+        this.log.info(`[AsrClient] Configured language="${language}" for call ${this.callId}`);
+      }
     } catch (err) {
       this.log.error(`[AsrClient] Failed to connect:`, err);
       throw err;
@@ -330,6 +339,7 @@ export class AsrManager extends EventEmitter {
 
   constructor(
     private asrUrl: string,
+    private language: string = "en",
     private log = console
   ) {
     super();
@@ -347,6 +357,7 @@ export class AsrManager extends EventEmitter {
       callId,
       {
         url: this.asrUrl,
+        language: this.language,
         reconnectDelay: 2000,
         maxReconnectAttempts: 10,
       },

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ const ConfigSchema = z.object({
   }),
   asr: z.object({
     url: z.string().url().optional(),
+    language: z.string().default("English"),
   }),
   tts: z.object({
     url: z.string().url().optional(),
@@ -53,6 +54,7 @@ export function loadConfig(): Config {
     },
     asr: {
       url: process.env.ASR_URL,
+      language: process.env.ASR_LANGUAGE,
     },
     tts: {
       url: process.env.TTS_URL,


### PR DESCRIPTION
## Summary
- ASR client sends `{"action": "config", "language": "English"}` on connect — prevents per-chunk auto-detection from flipping between languages on silence/noise
- `close()` waits for actual `is_final` response (2s timeout) instead of fixed 100ms delay
- Added `channel.ring()` so callers hear ringtone during the 3s pre-answer delay
- New `ASR_LANGUAGE` env var (default: `English`)

## Verified
- Called in, heard ringtone, transcription came through in English only, flush captured final word

Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)