### PR TITLE
fix: wait for WebSocket close before cleaning up ExternalMedia channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.6] - 2026-02-07
+
+### Fixed
+- **ExternalMedia channels lingering after call hangup** — WebSocket close was non-blocking, so the ExternalMedia channel stayed alive in Asterisk even after cleanup ran. Now waits for the WebSocket `close` event (with 2s timeout + `terminate()` fallback) before destroying bridges and hanging up channels. Fixes stuck "busy" state on extensions after calls.
+- Same fix applied to `audio-playback.ts` — TTS ExternalMedia channels now clean up properly too.
+
 ## [0.3.5] - 2026-02-07
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asterisk-api",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "type": "module",
   "description": "REST API bridge between OpenClaw and Asterisk/FreePBX via ARI",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- ExternalMedia channels in Asterisk stay alive as long as their WebSocket is connected
- `ws.close()` was non-blocking — cleanup ran before the channel was released, leaving stuck channels
- Extension showed "busy" after call ended because the audiocap channel was still alive
- Now waits for WebSocket `close` event (2s timeout + `terminate()` fallback) before destroying bridges and hanging up channels
- Applied to both `audio-capture.ts` and `audio-playback.ts`

## Test plan
- [ ] Call in, talk, hang up — verify no lingering channels (`asterisk -rx 'core show channels'`)
- [ ] Immediately call again — should not get "busy"

🤖 Generated with [Claude Code](https://claude.com/claude-code)